### PR TITLE
[Docs] Add docs/README.md — OctoAcme process overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# OctoAcme Project Management Process Docs
+
+Welcome — this folder contains OctoAcme’s living project management process documentation to help teams initiate, plan, execute, release, and continuously improve work.
+
+## OctoAcme Project Management Processes — Summary
+
+OctoAcme follows a lightweight, stage‑gated approach that moves work from initiation through planning, execution, release, and retrospective. Projects begin with a Project One‑pager to capture the problem, goals, success metrics, stakeholders, and a high‑level timeline. Planning turns the one‑pager into a prioritized backlog with acceptance criteria, estimates, a Definition of Done, and a release plan; risks and cross‑team dependencies are tracked in a Risk Register and surfaced during planning and weekly syncs.
+
+Day‑to‑day delivery is driven from a project board (Backlog → Ready → In Progress → In Review → QA → Done) and a disciplined pull‑request workflow that emphasizes small PRs with linked issues and acceptance criteria, CI (tests and linting) before review, and at least one approval prior to merge. Team rhythm includes short standups, weekly delivery syncs, demos/reviews at milestones, and execution checklists to maintain repeatable quality and visibility.
+
+Roles and responsibilities are explicit: Project Managers coordinate schedules, risks, and communications; Product Managers define outcomes and prioritize the backlog; Developers implement and test features; QA validates acceptance criteria; and stakeholders provide inputs and approvals. Quality assurance is layered — automated unit/integration tests, end‑to‑end smoke tests for critical flows, security scanning in CI, manual QA when needed, and standardized release/rollback playbooks. Retrospectives capture improvements and action items that are tracked back into the backlog.
+
+## Quick Links to Process Docs
+
+- octoacme-project-management-overview.md
+- octoacme-project-initiation.md
+- octoacme-project-planning.md
+- octoacme-execution-and-tracking.md
+- octoacme-risks-and-communication.md
+- octoacme-release-and-deployment.md
+- octoacme-retrospective-and-continuous-improvement.md
+- octoacme-roles-and-personas.md


### PR DESCRIPTION
This PR adds docs/README.md which provides a concise overview of OctoAcme's project management processes and quick links to the process documents in docs/.

Linked to: #3

Reviewer: @shawn-jung
Labels: documentation, process improvement